### PR TITLE
Create Nike Token

### DIFF
--- a/Nike Token
+++ b/Nike Token
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+
+/**
+ * @title MyNikeToken
+ * @dev This is a basic ERC20 token using the OpenZeppelin's ERC20PresetFixedSupply preset.
+ * You can edit the default values as needed.
+ */
+contract MyNikeToken is ERC20Burnable {
+
+    /**
+     * @dev Constructor to initialize the token with default values.
+     * You can edit these values as needed.
+     */
+    constructor() ERC20("DefaultTokenName", "Nike") {
+        // Default initial supply of 1 million tokens (with 18 decimals)
+        uint256 initialSupply = 1_000_000 * (10 ** 18);
+
+        // The initial supply is minted to the deployer's address
+        _mint(msg.sender, initialSupply);
+    }
+
+    // Additional functions or overrides can be added here if needed.
+}


### PR DESCRIPTION
// SPDX-License-Identifier: MIT

pragma solidity ^0.8.0;

import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

/**
 * @title MyNikeToken
 * @dev This is a basic ERC20 token using the OpenZeppelin's ERC20PresetFixedSupply preset.
 * You can edit the default values as needed.
 */
contract MyNikeToken is ERC20Burnable {

    /**
     * @dev Constructor to initialize the token with default values.
     * You can edit these values as needed.
     */
    constructor() ERC20("DefaultTokenName", "Nike") {
        // Default initial supply of 1 million tokens (with 18 decimals)
        uint256 initialSupply = 1_000_000 * (10 ** 18);

        // The initial supply is minted to the deployer's address
        _mint(msg.sender, initialSupply);
    }

    // Additional functions or overrides can be added here if needed.
}